### PR TITLE
Fix installation of text fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ venv
 
 build/
 dist/
+
+**.tar.gz

--- a/tests/compare_plot/utils.py
+++ b/tests/compare_plot/utils.py
@@ -1,11 +1,12 @@
 import bw2data as bd
-import bw2io as bi
+from ..conftest import restore_database
 
+
+# TBD: This should be a pytest fixture
 
 def sample_1():
-    bd.projects.set_current('compare-plot-test')
-    bi.useeio11()
-    eidb = bd.Database('USEEIO-1.1')
+    restore_database()
+    eidb = bd.Database('USEEIO-1.1-noproducts')
 
     methods = list(bd.methods)
 

--- a/tests/compare_plot/utils.py
+++ b/tests/compare_plot/utils.py
@@ -6,14 +6,10 @@ from ..conftest import restore_database
 
 def sample_1():
     restore_database()
-    eidb = bd.Database('USEEIO-1.1-noproducts')
-
     methods = list(bd.methods)
 
-    window_metal = [node for node in eidb if node['type'] == 'product' if node['name']
-                    == "Metal windows, doors, and architectural products; at manufacturer"][0]
-    window_wood = [node for node in eidb if node['type'] == 'product' if node['name']
-                   == "Wooden windows, door, and flooring; at manufacturer"][0]
+    window_metal = bd.get_node(name="Metal windows, doors, and architectural products; at manufacturer")
+    window_wood = bd.get_node(name="Wooden windows, door, and flooring; at manufacturer")
 
     fu={window_metal: 1, window_wood: 1}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 """Fixtures for bw_visualization"""
 
-import pytest
-import bw2data as bd
-
-import bw2io as bi
+from bw2data.tests import bw2test
 from pathlib import Path
+import bw2data as bd
+import bw2io as bi
 import requests
 
 
@@ -17,10 +16,11 @@ PROJECT_NAME = 'USEEIO-1.1-noproducts'
 
 def pytest_sessionstart(session):
     if not USEEIO_FIXTURE.exists():
+        print("Downloading US EEIO")
         URL = "https://files.brightway.dev/" + USEEIO_FILENAME
         request = requests.get(URL, stream=True)
         if request.status_code != 200:
-            raise NotFound(
+            raise ValueError(
                 "URL {} returns status code {}.".format(URL, request.status_code)
             )
         download = request.raw
@@ -33,7 +33,7 @@ def pytest_sessionstart(session):
                 f.write(segment)
 
 
-@pytest.fixture
+@bw2test
 def restore_database():
     bi.restore_project_directory(USEEIO_FIXTURE)
     bd.projects.set_current(PROJECT_NAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,20 +2,38 @@
 
 import pytest
 import bw2data as bd
-import bw2io as bi
 
-PROJECT_NAME = 'test'
-BACKUP_PATH = ''
+import bw2io as bi
+from pathlib import Path
+import requests
+
+
+FIXTURES_DIR = Path(__file__).parent.absolute() / "fixtures"
+FIXTURES_DIR.mkdir(exist_ok=True)
+USEEIO_FILENAME = "useeio.tar.gz"
+USEEIO_FIXTURE = FIXTURES_DIR / USEEIO_FILENAME
+PROJECT_NAME = 'USEEIO-1.1-noproducts'
 
 
 def pytest_sessionstart(session):
-    global BACKUP_PATH
-    bd.projects.set_current(PROJECT_NAME)
-    bi.useeio11(collapse_products=True, prune=True)
-    BACKUP_PATH = bi.backup_project_directory(PROJECT_NAME)  # backup_project_directory doesn't return file path and cant be used
+    if not USEEIO_FIXTURE.exists():
+        URL = "https://files.brightway.dev/" + USEEIO_FILENAME
+        request = requests.get(URL, stream=True)
+        if request.status_code != 200:
+            raise NotFound(
+                "URL {} returns status code {}.".format(URL, request.status_code)
+            )
+        download = request.raw
+        chunk = 128 * 1024
+        with open(USEEIO_FIXTURE, "wb") as f:
+            while True:
+                segment = download.read(chunk)
+                if not segment:
+                    break
+                f.write(segment)
 
 
 @pytest.fixture
 def restore_database():
-    bi.restore_project_directory(BACKUP_PATH)
+    bi.restore_project_directory(USEEIO_FIXTURE)
     bd.projects.set_current(PROJECT_NAME)

--- a/tests/database_explorer/utils.py
+++ b/tests/database_explorer/utils.py
@@ -1,13 +1,13 @@
 import bw2data as bd
-import bw2io as bi
 import bw2calc as bc
+from ..conftest import restore_database
 
+
+# TBD: This should be a pytest fixture
 
 def sample_1():
-    bd.projects.set_current('database-explorer-test')
-    bi.useeio11()
-
-    eidb = bd.Database('USEEIO-1.1')
+    restore_database()
+    eidb = bd.Database('USEEIO-1.1-noproducts')
     methods = list(bd.methods)
 
     methods_EF = methods

--- a/tests/database_explorer/utils.py
+++ b/tests/database_explorer/utils.py
@@ -10,10 +10,10 @@ def sample_1():
     eidb = bd.Database('USEEIO-1.1-noproducts')
     methods = list(bd.methods)
 
+    # TBD: WTF is this??
     methods_EF = methods
     methods_CC = methods
-    acts = [act for act in eidb if act['type']=='process' and act['name']=='Funds, trusts, and financial vehicles']
-    act = acts[0]
+    act = bd.get_node(name="Funds, trusts, and financial vehicles")
     lca = bc.LCA({act: 1}, methods[0])
     lca.lci()
 

--- a/tests/sankertainpy/utils.py
+++ b/tests/sankertainpy/utils.py
@@ -1,14 +1,11 @@
 import bw2data as bd
-import bw2io as bi
-import bw2calc as bc
+from ..conftest import restore_database
 
+
+# TBD: This should be a pytest fixture
 
 def sample_1():
-    bd.projects.set_current('sankertainpy-test')
-    bi.useeio11()
-
-    act = bd.Database('USEEIO-1.1').random({"name": "Cutlery and handtools; at manufacturer",
-                                            'code': '1fb0a77a-d49c-3557-810c-a4db0e73bab6'})
+    restore_database()
+    act = bd.get_node(name="Cutlery and handtools; at manufacturer")
     method = bd.methods.random()
-
     return act, method


### PR DESCRIPTION
It's really wasteful to download the raw USEEIO each time we run tests. Instead, this downloads a preprocessed project file. As the pruning step is stochastic, having all tests download the same project is the only way to get repeatability.